### PR TITLE
Allow hidden options to be used

### DIFF
--- a/lib/Getopt/Long/Descriptive.pm
+++ b/lib/Getopt/Long/Descriptive.pm
@@ -353,6 +353,13 @@ sub _build_describe_options {
 
     # not entirely sure that all of this (until the Usage->new) shouldn't be
     # moved into Usage -- rjbs, 2009-08-19
+
+    # all specs including hidden
+    my @getopt_specs =
+      map  { $_->{spec} }
+      grep { $_->{desc} ne 'spacer' }
+      @opts;
+
     my @specs =
       map  { $_->{spec} }
       grep { $_->{desc} ne 'spacer' }
@@ -387,7 +394,7 @@ sub _build_describe_options {
     Getopt::Long::Configure(@go_conf);
 
     my %return;
-    $usage->die unless GetOptions(\%return, grep { length } @specs);
+    $usage->die unless GetOptions(\%return, grep { length } @getopt_specs);
     my @given_keys = keys %return;
 
     for my $opt (keys %return) {

--- a/t/descriptive.t
+++ b/t/descriptive.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 40;
+use Test::More tests => 42;
 
 use_ok("Getopt::Long::Descriptive");
 
@@ -16,7 +16,7 @@ use_ok("Getopt::Long::Descriptive");
 sub is_opt {
   my ($argv, $specs, $expect, $desc) = @_;
   local @ARGV = @$argv;
-  eval { 
+  eval {
     my ($opt, $usage) = describe_options(
       "test %o",
       @$specs,
@@ -30,7 +30,7 @@ sub is_opt {
     for my $key (keys %$expect) {
       is($opt->$key, $expect->{$key}, "...->$key");
     }
-  }; 
+  };
   if ($@) {
     chomp($@);
     if (ref($expect) eq 'Regexp') {
@@ -86,17 +86,24 @@ is_hidden(
   qr/a bar option/,
 );
 
+is_opt(
+  [ '--nora' ],
+  [ [ "nora", "Invisible Nora", { hidden => 1 } ] ],
+  { nora => 1 },
+  "",
+);
+
 ### tests for one_of
 
-my $foobar = [ 
+my $foobar = [
   [ 'foo' => 'a foo option' ],
   [ 'bar' => 'a bar option' ],
 ];
 
 is_opt(
   [ ],
-  [ 
-    [ 
+  [
+    [
       mode => $foobar, { default => 'foo' },
     ],
   ],


### PR DESCRIPTION
Hello, I wrote you an email about week ago ... this update should enable hidden options to be used while still hidden from usage description.  I've also found report from someone else in RT with same problem.

If you think the change is reasonable, I'd be happy if you can integrate it.
