### PR TITLE
Adds "required" as additional constraint in SYNOPSIS	

### DIFF
--- a/lib/Getopt/Long/Descriptive.pm
+++ b/lib/Getopt/Long/Descriptive.pm
@@ -19,8 +19,8 @@ use Getopt::Long::Descriptive::Usage;
 
   my ($opt, $usage) = describe_options(
     'my-program %o <some-arg>',
-    [ 'server|s=s', "the server to connect to"                  ],
-    [ 'port|p=i',   "the port to connect to", { default => 79 } ],
+    [ 'server|s=s', "the server to connect to", { required => 1  } ],
+    [ 'port|p=i',   "the port to connect to",   { default  => 79 } ],
     [],
     [ 'verbose|v',  "print extra stuff"            ],
     [ 'help',       "print usage message and exit" ],


### PR DESCRIPTION
I realize that this is documented, but it wasn't immediately clear to me how to set an option as required so that the usage message would be printed if it wasn't supplied.  After some reading, I did eventually figure it out, but I thought it might be helpful to have this in the SYNOPSIS, since it strikes me as a fairly common use case and would make that concept somewhat clearer for people just getting started with this.
