### PR TITLE
Usage show args

### DIFF
--- a/lib/Getopt/Long/Descriptive.pm
+++ b/lib/Getopt/Long/Descriptive.pm
@@ -291,6 +291,14 @@ sub _strip_assignment {
 
   (my $copy = $str) =~ s{$SPEC_RE}{};
 
+  if (wantarray) {
+      my $len = length $copy;
+      my $assignment = substr $str, $len;
+      if (!defined($assignment)) {
+          $assignment = '';
+      }
+      return ($copy, $assignment);
+  }
   return $copy;
 }
 
@@ -369,7 +377,7 @@ sub _build_describe_options {
       sort  { lc $a cmp lc $b or $a cmp $b }
       grep  { /^.$/ }
       map   { split /\|/ }
-      map   { __PACKAGE__->_strip_assignment($_) }
+      map   { scalar __PACKAGE__->_strip_assignment($_) }
       @specs;
 
     my $long = grep /\b[^|]{2,}/, @specs;

--- a/lib/Getopt/Long/Descriptive/Usage.pm
+++ b/lib/Getopt/Long/Descriptive/Usage.pm
@@ -76,24 +76,23 @@ sub option_text {
 
   my @options  = @{ $self->{options} || [] };
   my $string   = q{};
-
-  # a spec can grow up to 4 characters in usage output:
-  # '-' on short option, ' ' between short and long, '--' on long
   my @specs = map { $_->{spec} } grep { $_->{desc} ne 'spacer' } @options;
-  my $length   = (max(map { length } @specs) || 0) + 4;
+  my $length   = (max(map { _option_length($_) } @specs) || 0);
   my $spec_fmt = "\t%-${length}s";
 
   while (@options) {
     my $opt  = shift @options;
     my $spec = $opt->{spec};
     my $desc = $opt->{desc};
+    my $assign;
     if ($desc eq 'spacer') {
       $string .= sprintf "$spec_fmt\n", $opt->{spec};
       next;
     }
 
-    $spec = Getopt::Long::Descriptive->_strip_assignment($spec);
-    $spec = join " ", reverse map { length > 1 ? "--$_" : "-$_" }
+    ($spec, $assign) = Getopt::Long::Descriptive->_strip_assignment($spec);
+    $assign = _parse_assignment($assign);
+    $spec = join " ", reverse map { length > 1 ? "--${_}$assign" : "-${_}$assign" }
                               split /\|/, $spec;
 
     my @desc = $self->_split_description($length, $desc);
@@ -107,6 +106,63 @@ sub option_text {
   }
 
   return $string;
+}
+
+sub _option_length {
+    my ($fullspec) = @_;
+    my $arglen = 0;
+    my $number_opts = 1;
+    my $last_pos = 0;
+    my $number_shortopts = 0;
+    my ($spec, $argspec) = Getopt::Long::Descriptive->_strip_assignment($fullspec);
+    my $length = length $spec;
+
+    # Spacing rules:
+    #
+    # For short options we want 1 space (for '-'), for long options 2
+    # spaces (for '--').  Then one space for separating the options,
+    # but we here abuse that $spec has a '|' char for that.
+    #
+    # For options that take arguments, we want 2 spaces for mandatory
+    # options ('=X') and 4 for optional arguments ('[=X]').  Note we
+    # consider {N,M} cases as "single argument" atm.
+
+    # Count the number of "variants" (e.g. "long|s" has two variants)
+    while ($spec =~ m{\|}g) {
+        $number_opts++;
+        if (pos($spec) - $last_pos == 2) {
+            $number_shortopts++;
+        }
+        $last_pos = pos($spec);
+    }
+
+    # Was the last option a "short" one?
+    if ($length - $last_pos == 2) {
+        $number_shortopts++;
+    }
+
+    # Do we have an argument specifier (ignoring "!" and "+")
+    if (length($argspec) >= 2) {
+        # yes, 2 for the argument
+        $arglen = 2;
+        if (substr($argspec, 0, 1) eq ':') {
+            # argument is optional, add another 2 for []
+            $arglen += 2;
+        }
+    }
+
+    # We got $number_opts options, each with an argument length of
+    # $arglen.  Plus each option (after the first) needs 3 a char
+    # spacing.  $length gives us the total length of all options and 1
+    # char spacing per option (after the first).  It does not account
+    # for argument length and we want (at least) one additional char
+    # for space before the description.  So the result should be:
+
+    my $number_longopts = $number_opts - $number_shortopts;
+    my $total_arglen = $number_opts * $arglen;
+    my $total_optsep = 2 * $number_longopts + $number_shortopts;
+    my $total = $length + $total_optsep + $total_arglen + 1;
+    return $total;
 }
 
 sub _split_description {
@@ -127,6 +183,26 @@ sub _split_description {
   push @lines, $desc;
 
   return @lines;
+}
+
+sub _parse_assignment {
+    my ($assign_spec) = @_;
+    my $argument;
+    my $result = 'X';
+    if (length($assign_spec) < 2) {
+        # empty, ! or +
+        return '';
+    }
+
+    $argument = substr $assign_spec, 1, 2;
+    if ($argument eq 'i') {
+        $result = 'N';
+    }
+    if (substr($assign_spec, 0, 1) eq ':') {
+        return "[=$result]";
+    }
+    # with leading space so it can just blindly be appended.
+    return " $result";
 }
 
 =head2 warn

--- a/t/descriptive.t
+++ b/t/descriptive.t
@@ -273,9 +273,9 @@ is_opt(
   );
 
   my $expect = qr/
-	--baz    a baz option with a very long description. It just goes on
-	         for a really long time. This allows us to test line wrapping
-	         and make sure the output always looks spiffy/;
+	--baz   a baz option with a very long description. It just goes on
+	        for a really long time. This allows us to test line wrapping
+	        and make sure the output always looks spiffy/;
 
 
   like($usage->text, $expect, 'long option description is wrapped cleanly');

--- a/t/descriptive.t
+++ b/t/descriptive.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 42;
+use Test::More tests => 46;
 
 use_ok("Getopt::Long::Descriptive");
 
@@ -204,6 +204,40 @@ is_opt(
     $usage->text,
     qr/\[-bhiloSs\]/,
     "short options",
+  );
+}
+
+{
+  local @ARGV;
+  my ($opt, $usage) = describe_options(
+    "%c %o",
+    [ 'string|s=s'   => "string value" ],
+    [ 'ostring|S:s'  => "optional string value" ],
+    [ 'list|l=s@'    => "list of strings" ],
+    [ 'hash|h=s%'    => "hash values" ],
+    [ 'optional|o!'  => "optional" ],
+    [ 'increment|i+' => "incremental option" ],
+  );
+  my $usage_text = $usage->text;
+  like(
+    $usage_text,
+    qr/-s STR --string STR\s+string value/,
+    "Spec =s gets an STR in usage output",
+  );
+  like(
+    $usage_text,
+    qr/-S\[=STR\] --ostring\[=STR\]\s+optional string value/,
+    "Spec :s gets an STR in usage output",
+  );
+  like(
+    $usage_text,
+    qr/-l STR\Q...\E --list STR\Q...\E\s+list of strings/,
+    "Spec =s@ gets an STR... in usage output",
+  );
+  like(
+    $usage_text,
+    qr/-h KEY=STR\Q...\E --hash KEY=STR\Q...\E\s+hash values/,
+    "Spec =s% gets an KEY=STR... in usage output",
   );
 }
 


### PR DESCRIPTION
Hi,

I have written two patches to display arguments in the usage output.  The patches were originally submitted to the cpan RT[1].  I believe it would (also) close the RT ticket #79982.

Thanks for considering,
~Niels

[1] https://rt.cpan.org/Public/Bug/Display.html?id=84487

NB: I rebased the patches there and merged 0002 and 0003 into one patch.

