### PR TITLE
add x_breaks metadata for MooseX::Getopt, and check it at install time

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -6,3 +6,9 @@ copyright_holder = Hans Dieter Pearcey
 copyright_year   = 2005
 
 [@RJBS]
+
+[Breaks]
+MooseX::Getopt = < 0.66
+
+[Test::CheckBreaks]
+conflicts_module = Moose::Conflicts


### PR DESCRIPTION
Might as well look for Moose-related breakages at the same time,
if Moose is installed.