### PR TITLE
Add minimum perl version to meta file using dzil plugin [MinimumPerl].

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -10,5 +10,6 @@ copyright_year   = 2005
 [Breaks]
 MooseX::Getopt = < 0.66
 
+[MinimumPerl]
 [Test::CheckBreaks]
 conflicts_module = Moose::Conflicts


### PR DESCRIPTION
Hi @rjbs 

Please review the PR.
This PR is done as part of PRC 2016.

Many Thanks.
Best Regards,
Mohammad S Anwar