### PR TITLE
Correct unescaped left brace in regex error.

### DIFF
--- a/lib/Getopt/Long/Descriptive.pm
+++ b/lib/Getopt/Long/Descriptive.pm
@@ -304,7 +304,7 @@ my %HIDDEN = (
   hidden => 1,
 );
 
-my $SPEC_RE = qr{(?:[:=][\d\w\+]+[%@]?({\d*,\d*})?|[!+])$};
+my $SPEC_RE = qr{(?:[:=][\d\w\+]+[%@]?(\{\d*,\d*\})?|[!+])$};
 sub _strip_assignment {
   my ($self, $str) = @_;
 


### PR DESCRIPTION
Detected when run against perl 5 blead v5.27.7-213-ga8e5118.