### PR TITLE
Fix Unescaped left brace in regex warning

### DIFF
--- a/lib/Getopt/Long/Descriptive.pm
+++ b/lib/Getopt/Long/Descriptive.pm
@@ -304,7 +304,7 @@ my %HIDDEN = (
   hidden => 1,
 );
 
-my $SPEC_RE = qr{(?:[:=][\d\w\+]+[%@]?({\d*,\d*})?|[!+])$};
+my $SPEC_RE = qr{(?:[:=][\d\w\+]+[%@]?(\{\d*,\d*\})?|[!+])$};
 sub _strip_assignment {
   my ($self, $str) = @_;
 


### PR DESCRIPTION
This is new in Perl 5.27.8. The perldelta claims this has been
deprecated for a while, but only warns with this release.