### PR TITLE
Generate accessors for all one_of options

### DIFF
--- a/lib/Getopt/Long/Descriptive.pm
+++ b/lib/Getopt/Long/Descriptive.pm
@@ -378,6 +378,10 @@ sub _build_describe_options {
           }
           $one_opt->{constraint}->{one_of} = $opt->{name};
           push @opts, $one_opt;
+
+          # Ensure that we generate accessors for all one_of sub-options
+          $method_map{ $one_opt->{name} } = undef
+            unless $one_opt->{desc} eq 'spacer';
         }
       }
 

--- a/t/descriptive.t
+++ b/t/descriptive.t
@@ -334,6 +334,22 @@ is_opt(
 }
 
 {
+  local @ARGV = qw(--get);
+  my ($opt, $usage) = describe_options(
+    "%c %o",
+    [ "mode" => hidden => { one_of => [
+      [ "get" => "get the value"  ],
+      [ "set" => "set the value" ],
+    ] } ],
+  );
+  is( $opt->{get}, 1, "one_of provided value (as hash key)" );
+  is( $opt->get,   1, "one_of provided value (as method)" );
+
+  is( $opt->{set}, undef, "one_of entry not given is undef (as hash key)" );
+  is( $opt->set,   undef, "one_of entry not given is undef (as method)");
+}
+
+{
   local @ARGV = qw(--foo-bar);
   my ($opt) = describe_options(
     "%c %o",


### PR DESCRIPTION
Given this opt spec:

```
[ "mode" => hidden => { one_of => [
    [ "get|g"  => "get the value" ],
    [ "set|s"  => "set the value" ],
] } ]
```

Before, if you provided only `--get`, you'd get `$opt->get` (set to 1),
and `$opt->mode` (set to "get"). But if you tried to call `$opt->set`,
the program would crash because we did not generate an accessor for
non-provided one_of options.

This was decidedly inconvenient, because sometimes I'd want to write
code like this (where type_one and type_two were children of a one_of
option):

```
if ($opt->type_one eq 'foo') { ... }
if ($opt->type_two eq 'bar'} { ... }
```

This fix just copies the method from 72c684ffb for all of
the children of a one_of option. Fixes #29.