### PR TITLE
overhaul formatting to be less awful

### DIFF
--- a/lib/Getopt/Long/Descriptive.pm
+++ b/lib/Getopt/Long/Descriptive.pm
@@ -287,6 +287,16 @@ my %CONSTRAINT = (
 
 our $MungeOptions = 1;
 
+our $TERM_WIDTH;
+{
+  if (eval { require Term::ReadKey; 1 }) {
+    my ($width) = Term::ReadKey::GetTerminalSize();
+    $TERM_WIDTH = $width;
+  } else {
+    $TERM_WIDTH = $ENV{COLUMNS} || 80;
+  }
+}
+
 sub _nohidden {
   return grep { ! $_->{constraint}->{hidden} } @_;
 }

--- a/t/descriptive.t
+++ b/t/descriptive.t
@@ -265,31 +265,31 @@ is_opt(
 
   like(
     $usage_text,
-    qr/-s STR --string STR\s+string value/,
+    qr/--string STR \(or -s\)\s+string value/,
     "Spec =s gets an STR in usage output",
   );
 
   like(
     $usage_text,
-    qr/-S\[=STR\] --ostring\[=STR\]\s+optional string value/,
+    qr/--ostring\[=STR\] \(or -S\)\s+optional string value/,
     "Spec :s gets an STR in usage output",
   );
 
   like(
     $usage_text,
-    qr/-l STR\Q...\E --list STR\Q...\E\s+list of strings/,
+    qr/--list STR\Q...\E \(or -l\)\s+list of strings/,
     "Spec =s@ gets an STR... in usage output",
   );
 
   like(
     $usage_text,
-    qr/-h KEY=STR\Q...\E --hash KEY=STR\Q...\E\s+hash values/,
+    qr/--hash KEY=STR\Q...\E \(or -h\)\s+hash values/,
     "Spec =s% gets an KEY=STR... in usage output",
   );
 
   like(
     $usage_text,
-    qr/-o --\[no-\]optional\s+optional boolean/,
+    qr/--\[no-\]optional \(or -o\)\s+optional boolean/,
     "Spec ! gets a [no-] in usage output",
   );
 }
@@ -365,6 +365,8 @@ is_opt(
 
 {
   local @ARGV;
+  local $Getopt::Long::Descriptive::TERM_WIDTH = 80;
+
   my ($opt, $usage) = describe_options(
     "test %o",
     [ foo => "a foo option" ],


### PR DESCRIPTION
An example program *before*:

```
	-p INT... --pid INT...                              only lines from
	                                                    these pids
	-i STR... -l STR... --ident STR...                  only lines from
	                                                    these idents
	--si STR... --subident STR...                       only lines from
	                                                    these subidents
	-f STR... --facility STR...                         only lines from
	                                                    these facilities
	-r STR... --role STR...                             only lines from
	                                                    hosts with these
	                                                    roles
	-m STR... -h STR... --machine STR... --host STR...  only lines from
	                                                    these hosts
```

…and after…

```
	--pid INT... (or -p)          only lines from these pids
	--ident STR... (or -l)        only lines from these idents
	                              aka -i
	--subident STR...             only lines from these subidents
	                              aka --si
	--facility STR... (or -f)     only lines from these facilities
	--role STR... (or -r)         only lines from hosts with these roles
	--host STR... (or -h)         only lines from these hosts
	                              aka --machine, -m
```