### PR TITLE
Adapt for changes in Getopt::Long warning output

### DIFF
--- a/t/descriptive.t
+++ b/t/descriptive.t
@@ -451,19 +451,38 @@ EOO
     );
   }
 
-  if (@warnings == 1) {
-    pass("got one warning about ambiguity of options");
-    like(
-      $warnings[0],
-      qr/these ambiguous options: f/,
-      "GLD warns on ambiguity for you",
-    );
-  } elsif (! @warnings) {
-    fail("got one warning about ambiguity of options");
-    diag("expected a warning but got none");
-  } else {
-    fail("got one warning about ambiguity of options");
-    diag("warning: $_") for @warnings;
+  note("Using Getopt::Long version $Getopt::Long::VERSION");
+  if ($Getopt::Long::VERSION < 2.55) {
+    if (@warnings == 1) {
+      pass("got one warning about ambiguity of options");
+      like(
+        $warnings[0],
+        qr/these ambiguous options: f/,
+        "GLD warns on ambiguity for you",
+      );
+    } elsif (! @warnings) {
+      fail("got one warning about ambiguity of options");
+      diag("expected a warning but got none");
+    } else {
+      fail("got one warning about ambiguity of options");
+      diag("warning: $_") for @warnings;
+    }
+  }
+  else {
+    if (@warnings == 2) {
+      pass("got two warnings about ambiguity of options");
+      like(
+        $warnings[0],
+        qr/these ambiguous options: f/,
+        "GLD warns on ambiguity for you",
+      );
+    } elsif (! @warnings) {
+      fail("got two warnings about ambiguity of options");
+      diag("expected two warnings but got none");
+    } else {
+      fail("got two warnings about ambiguity of options");
+      diag("warning: $_") for @warnings;
+    }
   }
 }
 


### PR DESCRIPTION
In Getopt-Long-2.55 a long-standing bug was fixed, but this had a side effect of emitting a warning where none was previously emitted. Consequently, tests in t/descriptive.t which depended on a count of warnings being emitted need to be adjusted.

See discussion in https://github.com/Perl/perl5/issues/21640.  Also note that, per https://metacpan.org/dist/Getopt-Long/changes, this new warning will one day become a fatal error.  So this patch is mainly intended to stanch the bleeding on CPANtesters.