### PR TITLE
Concatenate user-provided callbacks into hash.

### DIFF
--- a/lib/Getopt/Long/Descriptive.pm
+++ b/lib/Getopt/Long/Descriptive.pm
@@ -565,6 +565,12 @@ sub _validate_with {
           $arg{opts},
         ),
       };
+    } elsif ($ct eq 'callbacks') {
+      $pvspec{callbacks} ||= {};
+      $pvspec{callbacks} = {
+        %{$pvspec{callbacks}},
+        %{$spec->{$ct}},
+      };
     } else {
       %pvspec = (
         %pvspec,


### PR DESCRIPTION
Otherwise one created by e.g. use of implies can be overridden by one supplied by the user.

Fixes #38 